### PR TITLE
Miscellaneous fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,25 +88,25 @@ func main() {
 		for _, t := range ts {
 			wg.Add(1)
 
-			go func(t Target) {
+			go func(p Player, t Target) {
 				defer wg.Done()
 
 				playerLog, errs := p.Subscribe()
 				for {
 					select {
 					case cur := <-playerLog:
-						go func(t Target) {
-							logger.Printf("now playing: %s by %s\n", cur.Track.Title, cur.Track.Artist)
-							t.SubmitPlayingNow(cur.Track)
-							createTimer(p, t, cur)
-						}(t)
+						go func(p Player, t Target, status playerStatus) {
+							logger.Printf("now playing: %s by %s\n", status.Track.Title, status.Track.Artist)
+							t.SubmitPlayingNow(status.Track)
+							createTimer(p, t, status)
+						}(p, t, cur)
 					case e := <-errs:
 						// player errors are bound to fill up, should the connection be lost.
 						// TODO: find a better way to deal with player error logs
 						logger.Println(e)
 					}
 				}
-			}(t)
+			}(p, t)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -92,17 +92,19 @@ func main() {
 				defer wg.Done()
 
 				playerLog, errs := p.Subscribe()
-				select {
-				case cur := <-playerLog:
-					go func(t Target) {
-						logger.Printf("now playing: %s by %s\n", cur.Track.Title, cur.Track.Artist)
-						t.SubmitPlayingNow(cur.Track)
-						createTimer(p, t, cur)
-					}(t)
-				case e := <-errs:
-					// player errors are bound to fill up, should the connection be lost.
-					// TODO: find a better way to deal with player error logs
-					logger.Println(e)
+				for {
+					select {
+					case cur := <-playerLog:
+						go func(t Target) {
+							logger.Printf("now playing: %s by %s\n", cur.Track.Title, cur.Track.Artist)
+							t.SubmitPlayingNow(cur.Track)
+							createTimer(p, t, cur)
+						}(t)
+					case e := <-errs:
+						// player errors are bound to fill up, should the connection be lost.
+						// TODO: find a better way to deal with player error logs
+						logger.Println(e)
+					}
 				}
 			}(t)
 		}


### PR DESCRIPTION
This PR fixes a bug where multiple targets would not work right due to how goroutines were (not) being created. It also fixes an issue where the default logger was being used, rather than the correct logger.

Additionally, fewer goroutines will be created now, since I switched over to a `select` statement to read from both the `playerLog` and `errs` channels in the same goroutine.